### PR TITLE
Use modern extension import method in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ Create a :class:`Freezer` instance with your ``app`` object and call its
 :meth:`~Freezer.freeze` method. Put that in a ``freeze.py`` script
 (or call it whatever you like)::
 
-    from flask_frozen import Freezer
+    from flask.ext.frozen import Freezer
     from myapplication import app
 
     freezer = Freezer(app)


### PR DESCRIPTION
The `flask.ext` module has existed since Flask 0.8, which was
released in 2011, so it should be safe to recommend this way.