### PR TITLE
Revert "Use modern extension import method in docs"

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ Create a :class:`Freezer` instance with your ``app`` object and call its
 :meth:`~Freezer.freeze` method. Put that in a ``freeze.py`` script
 (or call it whatever you like)::
 
-    from flask.ext.frozen import Freezer
+    from flask_frozen import Freezer
     from myapplication import app
 
     freezer = Freezer(app)


### PR DESCRIPTION
Reverts SimonSapin/Frozen-Flask#47

`flask.ext` is apparently [being deprecated](https://github.com/SimonSapin/Frozen-Flask/pull/47#issuecomment-87400275).