### PR TITLE
Set endpoint name to generator name when the generator yields strings

### DIFF
--- a/flask_frozen/__init__.py
+++ b/flask_frozen/__init__.py
@@ -198,7 +198,9 @@ class Freezer(object):
                 for generated in generator():
                     if isinstance(generated, basestring):
                         url = generated
-                        endpoint = None
+                        # The endpoint defaults to the name of the
+                        # generator function, just like with Flask views.
+                        endpoint = generator.__name__
                     else:
                         if isinstance(generated, Mapping):
                             values = generated


### PR DESCRIPTION
This PR would fix the `MissingURLGeneratorWarning` warning when using following configuration.

```
@app.route('/page/<int:code>/')
def page(code):
    return str(code)
```
```
@freezer.register_generator
def page():
    return ('/page/{}/'.format(code) for code in range(1, 5))
```